### PR TITLE
Adding a new console command to get state of feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `feature-flags` will be documented in this file
 
+## 1.2.0 - 2019-10-25
+
+- Adds a new console command `feature:state` to report the current state of a feature flag.
+
 ## 1.1.0 - 2019-09-06
 
 - Fixes incorrect logic for handling features that are off and being check via the middleware or validations.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,13 @@ php artisan feature:on my-feature
 php artisan feature:off my-feature
 ```
 
+To find out the current state of the feature within the context of a
+console command, run the following:
+
+```bash
+php artisan feature:state my-feature
+```
+
 ### Testing
 
 ``` bash

--- a/src/Commands/CheckFeatureState.php
+++ b/src/Commands/CheckFeatureState.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace YlsIdeas\FeatureFlags\Commands;
+
+use Illuminate\Console\Command;
+use YlsIdeas\FeatureFlags\Facades\Features;
+
+class CheckFeatureState extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'feature:state {feature}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Gets the current state of the specified feature flag';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     * @throws \ErrorException
+     */
+    public function handle()
+    {
+        $feature = $this->argument('feature');
+
+        if (is_null($feature) || is_array($feature)) {
+            throw new \ErrorException('Feature argument must be a string');
+        }
+
+        $state = Features::accessible($feature);
+
+        $this->line(
+            sprintf(
+                'Feature `%s` is currently %s',
+                $feature, $state ? 'on' : 'off'
+            )
+        );
+    }
+}

--- a/src/FeatureFlagsServiceProvider.php
+++ b/src/FeatureFlagsServiceProvider.php
@@ -14,6 +14,7 @@ use YlsIdeas\FeatureFlags\Contracts\Repository;
 use Illuminate\Contracts\Foundation\Application;
 use YlsIdeas\FeatureFlags\Commands\SwitchOnFeature;
 use YlsIdeas\FeatureFlags\Commands\SwitchOffFeature;
+use YlsIdeas\FeatureFlags\Commands\CheckFeatureState;
 use YlsIdeas\FeatureFlags\Repositories\ChainRepository;
 use YlsIdeas\FeatureFlags\Repositories\RedisRepository;
 use YlsIdeas\FeatureFlags\Repositories\DatabaseRepository;
@@ -40,6 +41,7 @@ class FeatureFlagsServiceProvider extends ServiceProvider
             // Registering package commands.
             if (Features::usesCommands()) {
                 $this->commands([
+                    CheckFeatureState::class,
                     SwitchOnFeature::class,
                     SwitchOffFeature::class,
                 ]);

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -48,4 +48,20 @@ class CommandsTest extends TestCase
 
         $this->assertFalse(Features::accessible('my-feature'));
     }
+
+    /** @test */
+    public function getFeatureState()
+    {
+        Features::turnOn('my-feature');
+
+        $this->artisan('feature:state', ['feature' => 'my-feature'])
+            ->expectsOutput('Feature `my-feature` is currently on')
+            ->assertExitCode(0);
+
+        Features::turnOff('my-feature');
+
+        $this->artisan('feature:state', ['feature' => 'my-feature'])
+            ->expectsOutput('Feature `my-feature` is currently off')
+            ->assertExitCode(0);
+    }
 }


### PR DESCRIPTION
I use this package for determining whether or not to run some additional logic on a Laravel observer, so it is not particularly easy for me to see the status of a feature flag on a given page. Right now the workflow to see the state is to open a `php artisan tinker` session and run `Feature::accessible`.

With this PR, the state can be fetched much easier through a console command.

```bash
$ php artisan feature:state my-feature
Feature `my-feature` is currently on
```

NOTE: This may not report the correct state if the flag is togged dynamically based on an incoming request. However, this works for the majority of use cases I feel.