### PR TITLE
Corrects use of the update_on_resolve config option

### DIFF
--- a/src/FeatureFlagsServiceProvider.php
+++ b/src/FeatureFlagsServiceProvider.php
@@ -94,7 +94,8 @@ class FeatureFlagsServiceProvider extends ServiceProvider
             return new ChainRepository(
                 $this->app->make(Manager::class),
                 config('features.repositories.chain.drivers'),
-                config('features.repositories.chain.store')
+                config('features.repositories.chain.store'),
+                config('features.repositories.chain.update_on_resolve')
             );
         });
     }


### PR DESCRIPTION
Fixes `update_on_resolve` not being used in the service provider to create the chain repository as noted by issue #7.