### PR TITLE
Add support for dot notated config file features

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ You can use the accessible method to check if a feature is on or off.
 Features::accessible('my-feature') // returns true or false
 ```
 
+Dot notation can also be used if e.g. memory based driver uses multidimensional configuration. 
+
+```php
+Features::accessible('my.feature') // returns true or false
+```
+
 ### Blade Views
 
 the `@feature` blade directive is a simple `@if` shortcut to hide or display certain parts of the view

--- a/src/Repositories/InMemoryRepository.php
+++ b/src/Repositories/InMemoryRepository.php
@@ -2,6 +2,7 @@
 
 namespace YlsIdeas\FeatureFlags\Repositories;
 
+use Illuminate\Support\Arr;
 use YlsIdeas\FeatureFlags\Contracts\Repository;
 
 class InMemoryRepository implements Repository
@@ -13,11 +14,9 @@ class InMemoryRepository implements Repository
 
     public function __construct(array $config)
     {
-        $this->config = collect($config)
-            ->map(function ($item) {
-                return (bool) value($item);
-            })
-            ->toArray();
+        foreach (Arr::dot($config) as $key => $value) {
+            data_set($this->config, $key, (bool) value($value));
+        }
     }
 
     public function accessible(string $feature)

--- a/tests/Repositories/InMemoryRepositoryTest.php
+++ b/tests/Repositories/InMemoryRepositoryTest.php
@@ -18,6 +18,16 @@ class InMemoryRepositoryTest extends TestCase
     }
 
     /** @test */
+    public function itReturnsTrueIfDotNotatedFeaturesAreAccessible()
+    {
+        $repository = new InMemoryRepository([
+            'my.feature' => true,
+        ]);
+
+        $this->assertTrue($repository->accessible('my.feature'));
+    }
+
+    /** @test */
     public function itReturnsFalseIfFeaturesAreNotAccessible()
     {
         $repository = new InMemoryRepository([
@@ -25,6 +35,16 @@ class InMemoryRepositoryTest extends TestCase
         ]);
 
         $this->assertFalse($repository->accessible('my-feature'));
+    }
+
+    /** @test */
+    public function itReturnsFalseIfDotNotatedFeaturesAreNotAccessible()
+    {
+        $repository = new InMemoryRepository([
+            'my.feature' => false,
+        ]);
+
+        $this->assertFalse($repository->accessible('my.feature'));
     }
 
     /** @test */


### PR DESCRIPTION
**Problem**
In memory repository does not support dot notation in feature flag names. This forces feature flags in the configuration file to use single dimensional array construct.

The InMemoryRepository already supports dot notation in public methods, but constructor maps data only into first array key. 

**Solution**
Modified InMemoryRepository to retain multidimensional configuration.