### PR TITLE
Set getContainer Public

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -207,7 +207,7 @@ class Manager extends BaseManager implements Repository
         return $this->useCommands;
     }
 
-    protected function getContainer()
+    public function getContainer()
     {
         return $this->app ?? $this->container;
     }


### PR DESCRIPTION
Laravel 8.35 added a `public function getContainer()` to `Illuminate\Support\Manager` that is identical in functionality, with regard to Laravel 8, to the `protected function getContainer()` in `YlsIdeas\FeatureFlags\Manager` 

This pull request just makes the `YlsIdeas\FeatureFlags\Manager` version public to avoid the conflict.  It can't be removed as $this->app is important to Laravel 6 & 7