### PR TITLE
Fix PHP access level error

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -207,7 +207,7 @@ class Manager extends BaseManager implements Repository
         return $this->useCommands;
     }
 
-    protected function getContainer()
+    public function getContainer()
     {
         return $this->app ?? $this->container;
     }


### PR DESCRIPTION
When installing this package with laravel 8, php 7.4, i get this error:
```
PHP Fatal error:  Access level to YlsIdeas\FeatureFlags\Manager::getContainer() must be public (as in class Illuminate\Support\Manager) in /var/www/vendor/ylsideas/feature-flags/src/Manager.php on line 210
PHP Fatal error:  Uncaught ErrorException: Function must be enabled in php.ini by setting 'xdebug.mode' to 'develop' in /var/www/vendor/symfony/error-handler/Error/FatalError.php:37
```

This PR fixes it.