### PR TITLE
Fix ChainProvider all() method to prevent wrongly overwritten feature states

### DIFF
--- a/src/Repositories/ChainRepository.php
+++ b/src/Repositories/ChainRepository.php
@@ -70,12 +70,13 @@ class ChainRepository implements Repository
      */
     public function all()
     {
-        $features = collect();
+        $features = [];
+
         foreach ($this->repositories as $driver) {
-            $features = $features->merge($this->manager->driver($driver)->all());
+            $features = array_merge($this->manager->driver($driver)->all(), $features);
         }
 
-        return $features->toArray();
+        return $features;
     }
 
     /**

--- a/tests/Repositories/ChainRepositoryTest.php
+++ b/tests/Repositories/ChainRepositoryTest.php
@@ -209,11 +209,48 @@ class ChainRepositoryTest extends TestCase
         );
 
         $this->assertSame($repository->all(), [
-            'my-feature' => true,
-
-            'my-third-feature' => true,
-            'my-fourth-feature' => false,
+            'my-feature' => false,
             'my-second-feature' => true,
+            'my-fourth-feature' => true,
+            'my-third-feature' => true,
+        ]);
+    }
+
+    public function itRespectsTheChainOrder() {
+        $manager = \Mockery::mock(Manager::class);
+        $databaseRepository = \Mockery::mock(DatabaseRepository::class);
+        $inMemoryRepository = \Mockery::mock(InMemoryRepository::class);
+
+        $manager->shouldReceive('driver')
+            ->with('database')
+            ->once()
+            ->andReturn($databaseRepository);
+
+        $manager->shouldReceive('driver')
+            ->with('config')
+            ->once()
+            ->andReturn($inMemoryRepository);
+
+        $inMemoryRepository->shouldReceive('all')
+            ->once()
+            ->andReturn([
+                'my-feature' => false,
+            ]);
+
+        $databaseRepository->shouldReceive('all')
+            ->once()
+            ->andReturn([
+                'my-feature' => true,
+            ]);
+
+        $repository = new ChainRepository(
+            $manager,
+            ['config', 'database'],
+            'database'
+        );
+
+        $this->assertSame($repository->all(), [
+            'my-feature' => false,
         ]);
     }
 


### PR DESCRIPTION
The ChainRepository's `all()` function returns some incorrect feature states. This happens because the method merges the outputs of the different repositories in the wrong order, causing feature states from a "more important" repository to be overwritten by a "less important" repository.

For example, if the configured order of the drivers in the config is `['config', 'database']` and the feature "myFeature" is configured in the config as `true` and in the database as `false`, the call `Features::accessible('myFeature')` correctly returns `true` since the config driver is more important than the database driver. However, `Features::all()` returns the following array:  `['myFeature' => false]`, which is incorrect and happens because the `merge` function replaces the existing keys from the previous iteration. This is solved by "reverting" arguments in the `array_merge` method to prevent existing keys from being overwritten.