### PR TITLE
Change turnOn & turnOff to all active drivers

### DIFF
--- a/src/Repositories/ChainRepository.php
+++ b/src/Repositories/ChainRepository.php
@@ -85,7 +85,9 @@ class ChainRepository implements Repository
      */
     public function turnOn(string $feature)
     {
-        $this->manager->driver($this->stateDriver)->turnOn($feature);
+        foreach ($this->repositories as $driver) {
+            $this->manager->driver($driver)->turnOn($feature);
+        }
     }
 
     /**
@@ -94,6 +96,8 @@ class ChainRepository implements Repository
      */
     public function turnOff(string $feature)
     {
-        $this->manager->driver($this->stateDriver)->turnOff($feature);
+        foreach ($this->repositories as $driver) {
+            $this->manager->driver($driver)->turnOff($feature);
+        }
     }
 }

--- a/tests/Repositories/ChainRepositoryTest.php
+++ b/tests/Repositories/ChainRepositoryTest.php
@@ -302,7 +302,7 @@ class ChainRepositoryTest extends TestCase
             ->andReturn($databaseRepository);
 
         $manager->shouldReceive('driver')
-            ->with('database')
+            ->with('config')
             ->once()
             ->andReturn($inMemoryRepository);
 

--- a/tests/Repositories/ChainRepositoryTest.php
+++ b/tests/Repositories/ChainRepositoryTest.php
@@ -260,13 +260,23 @@ class ChainRepositoryTest extends TestCase
     {
         $manager = \Mockery::mock(Manager::class);
         $databaseRepository = \Mockery::mock(DatabaseRepository::class);
+        $inMemoryRepository = \Mockery::mock(InMemoryRepository::class);
 
         $manager->shouldReceive('driver')
             ->with('database')
             ->once()
             ->andReturn($databaseRepository);
 
+        $manager->shouldReceive('driver')
+            ->with('config')
+            ->once()
+            ->andReturn($inMemoryRepository);
+
         $databaseRepository->shouldReceive('turnOn')
+            ->with('my-feature')
+            ->once();
+
+        $inMemoryRepository->shouldReceive('turnOn')
             ->with('my-feature')
             ->once();
 
@@ -284,13 +294,23 @@ class ChainRepositoryTest extends TestCase
     {
         $manager = \Mockery::mock(Manager::class);
         $databaseRepository = \Mockery::mock(DatabaseRepository::class);
+        $inMemoryRepository = \Mockery::mock(InMemoryRepository::class);
 
         $manager->shouldReceive('driver')
             ->with('database')
             ->once()
             ->andReturn($databaseRepository);
 
+        $manager->shouldReceive('driver')
+            ->with('database')
+            ->once()
+            ->andReturn($inMemoryRepository);
+
         $databaseRepository->shouldReceive('turnOff')
+            ->with('my-feature')
+            ->once();
+
+        $inMemoryRepository->shouldReceive('turnOff')
             ->with('my-feature')
             ->once();
 


### PR DESCRIPTION
This addresses issue #23 by making sure turnOn and turnOff are called on all active drivers when using the chain driver.  Without this change calling, turnOn or turnOff only results in chaining the value in the storage driver. In the case of the default set ['config', 'redis', 'database'] calling turnOff or turnOn will not update the Redis storage and thus will have no effect on the results of `Features::accessible`