### PR TITLE
Add support for illuminate/support 9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "illuminate/support": "^8.0|^7.0|^6.0"
+        "illuminate/support": "^9.0|^8.0|^7.0|^6.0"
     },
     "require-dev": {
         "brianium/paratest": "^6.2",


### PR DESCRIPTION
Test suite still passes with Illuminate 9.0.

Still seems to work in my application.

Let me know if you'd like me to take any other steps.