### PR TITLE
Implement a middleware message

### DIFF
--- a/src/Middlewares/GuardFeature.php
+++ b/src/Middlewares/GuardFeature.php
@@ -19,14 +19,20 @@ class GuardFeature
     {
     }
 
-    public function handle(Request $request, Closure $next, string $feature, string $state = 'on', $abort = 403): mixed
-    {
+    public function handle(
+        Request $request,
+        Closure $next,
+        string $feature,
+        string $state = 'on',
+        $abort = 403,
+        $message = '',
+    ): mixed {
         if (
             ($this->check($state)
                 ? ! $this->manager->accessible($feature)
                 : $this->manager->accessible($feature))
         ) {
-            $this->application->abort($abort);
+            $this->application->abort($abort, $message);
         }
 
         return $next($request);

--- a/src/Middlewares/GuardFeature.php
+++ b/src/Middlewares/GuardFeature.php
@@ -3,6 +3,8 @@
 namespace YlsIdeas\FeatureFlags\Middlewares;
 
 use Closure;
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Contracts\Translation\Translator;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 use YlsIdeas\FeatureFlags\Manager;
@@ -15,10 +17,16 @@ class GuardFeature
 {
     use StateChecking;
 
-    public function __construct(protected Manager $manager, protected Application $application)
-    {
+    public function __construct(
+        protected Manager $manager,
+        protected Application $application,
+        protected Translator $translator,
+    ) {
     }
 
+    /**
+     * @throws BindingResolutionException
+     */
     public function handle(
         Request $request,
         Closure $next,
@@ -32,7 +40,7 @@ class GuardFeature
                 ? ! $this->manager->accessible($feature)
                 : $this->manager->accessible($feature))
         ) {
-            $this->application->abort($abort, $message);
+            $this->application->abort($abort, $this->translator->get($message));
         }
 
         return $next($request);

--- a/tests/Middlewares/GuardFeatureTest.php
+++ b/tests/Middlewares/GuardFeatureTest.php
@@ -22,7 +22,7 @@ class GuardFeatureTest extends TestCase
         $app = \Mockery::mock(Application::class);
 
         $app->shouldReceive('abort')
-            ->with(403)
+            ->with(403, '')
             ->once()
             ->andThrow($exception);
 
@@ -49,7 +49,7 @@ class GuardFeatureTest extends TestCase
         $app = \Mockery::mock(Application::class);
 
         $app->shouldReceive('abort')
-            ->with(403)
+            ->with(403, '')
             ->once()
             ->andThrow($exception);
 
@@ -73,7 +73,7 @@ class GuardFeatureTest extends TestCase
         $app = \Mockery::mock(Application::class);
 
         $app->shouldReceive('abort')
-            ->with(403)
+            ->with(403, '')
             ->never();
 
         $manager = \Mockery::mock(Manager::class);
@@ -106,7 +106,7 @@ class GuardFeatureTest extends TestCase
         $app = \Mockery::mock(Application::class);
 
         $app->shouldReceive('abort')
-            ->with(404)
+            ->with(404, '')
             ->once()
             ->andThrow($exception);
 
@@ -123,5 +123,32 @@ class GuardFeatureTest extends TestCase
 
         $middleware->handle($request, function () {
         }, 'my-feature', 'on', 404);
+    }
+
+    public function test_it_can_abort_requests_with_a_specified_message(): void
+    {
+        $exception = new HttpException(404, 'simple message');
+
+        $this->expectExceptionObject($exception);
+        $app = \Mockery::mock(Application::class);
+
+        $app->shouldReceive('abort')
+            ->with(404, 'simple message')
+            ->once()
+            ->andThrow($exception);
+
+        $manager = \Mockery::mock(Manager::class);
+
+        $manager->shouldReceive('accessible')
+            ->with('my-feature')
+            ->once()
+            ->andReturn(false);
+
+        $request = new Request();
+
+        $middleware = new GuardFeature($manager, $app);
+
+        $middleware->handle($request, function () {
+        }, 'my-feature', 'on', 404, 'simple message');
     }
 }

--- a/tests/Middlewares/GuardFeatureTest.php
+++ b/tests/Middlewares/GuardFeatureTest.php
@@ -2,6 +2,7 @@
 
 namespace YlsIdeas\FeatureFlags\Tests\Middlewares;
 
+use Illuminate\Contracts\Translation\Translator;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
@@ -20,6 +21,7 @@ class GuardFeatureTest extends TestCase
 
         $this->expectExceptionObject($exception);
         $app = \Mockery::mock(Application::class);
+        $translator = \Mockery::mock(Translator::class);
 
         $app->shouldReceive('abort')
             ->with(403, '')
@@ -33,12 +35,17 @@ class GuardFeatureTest extends TestCase
             ->once()
             ->andReturn(false);
 
+        $translator->shouldReceive('get')
+            ->with('')
+            ->once()
+            ->andReturn('');
+
         $request = new Request();
 
-        $middleware = new GuardFeature($manager, $app);
+        $middleware = new GuardFeature($manager, $app, $translator);
 
         $middleware->handle($request, function () {
-        }, 'my-feature', 'on');
+        }, 'my-feature');
     }
 
     public function test_it_can_abort_requests_when_features_are_not_accessible_and_expecting_to_be_off(): void
@@ -47,6 +54,7 @@ class GuardFeatureTest extends TestCase
 
         $this->expectExceptionObject($exception);
         $app = \Mockery::mock(Application::class);
+        $translator = \Mockery::mock(Translator::class);
 
         $app->shouldReceive('abort')
             ->with(403, '')
@@ -60,9 +68,14 @@ class GuardFeatureTest extends TestCase
             ->once()
             ->andReturn(true);
 
+        $translator->shouldReceive('get')
+            ->with('')
+            ->once()
+            ->andReturn('');
+
         $request = new Request();
 
-        $middleware = new GuardFeature($manager, $app);
+        $middleware = new GuardFeature($manager, $app, $translator);
 
         $middleware->handle($request, function () {
         }, 'my-feature', 'off');
@@ -71,6 +84,7 @@ class GuardFeatureTest extends TestCase
     public function test_it_continues_the_chain_if_features_are_accessible(): void
     {
         $app = \Mockery::mock(Application::class);
+        $translator = \Mockery::mock(Translator::class);
 
         $app->shouldReceive('abort')
             ->with(403, '')
@@ -83,9 +97,11 @@ class GuardFeatureTest extends TestCase
             ->once()
             ->andReturn(true);
 
+        $translator->shouldNotReceive('get');
+
         $expectedRequest = new Request();
 
-        $middleware = new GuardFeature($manager, $app);
+        $middleware = new GuardFeature($manager, $app, $translator);
 
         $this->assertTrue($middleware->handle(
             $expectedRequest,
@@ -104,6 +120,7 @@ class GuardFeatureTest extends TestCase
 
         $this->expectExceptionObject($exception);
         $app = \Mockery::mock(Application::class);
+        $translator = \Mockery::mock(Translator::class);
 
         $app->shouldReceive('abort')
             ->with(404, '')
@@ -117,9 +134,14 @@ class GuardFeatureTest extends TestCase
             ->once()
             ->andReturn(false);
 
+        $translator->shouldReceive('get')
+            ->with('')
+            ->once()
+            ->andReturn('');
+
         $request = new Request();
 
-        $middleware = new GuardFeature($manager, $app);
+        $middleware = new GuardFeature($manager, $app, $translator);
 
         $middleware->handle($request, function () {
         }, 'my-feature', 'on', 404);
@@ -131,6 +153,7 @@ class GuardFeatureTest extends TestCase
 
         $this->expectExceptionObject($exception);
         $app = \Mockery::mock(Application::class);
+        $translator = \Mockery::mock(Translator::class);
 
         $app->shouldReceive('abort')
             ->with(404, 'simple message')
@@ -144,9 +167,14 @@ class GuardFeatureTest extends TestCase
             ->once()
             ->andReturn(false);
 
+        $translator->shouldReceive('get')
+            ->with('simple message')
+            ->once()
+            ->andReturn('simple message');
+
         $request = new Request();
 
-        $middleware = new GuardFeature($manager, $app);
+        $middleware = new GuardFeature($manager, $app, $translator);
 
         $middleware->handle($request, function () {
         }, 'my-feature', 'on', 404, 'simple message');


### PR DESCRIPTION
## Changes In Code

Adds the ability to provide a string or translatable key to use with the middleware as a message for the response.

## Issue ticket number / Business Case

It allows for more flexibility with the middleware to explain why a feature is not accessible.

## Checklist before requesting a review
- [x] I have written PHP tests.
- [x] I have updated the documentation in the readme where needed.
- [x] I have checked code styles, PHPStan etc. pass.
- [x] I have provided an issue/business case.
