### PR TITLE
Maintenance mode with flags

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/contracts": "10.*|9.*"
+        "illuminate/contracts": "10.*|^9.6"
     },
     "require-dev": {
         "laravel/pint": "^1.2",

--- a/src/Contracts/Maintenance.php
+++ b/src/Contracts/Maintenance.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace YlsIdeas\FeatureFlags\Contracts;
+
+interface Maintenance
+{
+    public function active(): bool;
+
+    public function parameters(): ?array;
+
+    public function callActivation(array $properties): void;
+
+    public function callDeactivation(): void;
+}

--- a/src/Facades/Features.php
+++ b/src/Facades/Features.php
@@ -28,6 +28,7 @@ use YlsIdeas\FeatureFlags\Support\FeatureFake;
  * @method static \static callOnExpiredFeatures(array $expiredFeatures, callable|null $handler = null)
  * @method static \static applyOnExpiredHandler(\YlsIdeas\FeatureFlags\Contracts\ExpiredFeaturesHandler $handler)
  * @method static \static extend(string $driver, callable $builder)
+ * @method static \YlsIdeas\FeatureFlags\Support\MaintenanceRepository maintenanceMode()
  * @method static void assertAccessed(string $feature, int|null $count = null, string $message = '')
  * @method static void assertNotAccessed(string $feature, string $message = '')
  * @method static void assertAccessedCount(string $feature, int $count = 0, string $message = '')

--- a/src/FeatureFlagsServiceProvider.php
+++ b/src/FeatureFlagsServiceProvider.php
@@ -93,7 +93,7 @@ class FeatureFlagsServiceProvider extends ServiceProvider
         }
 
         $this->app->scoped(MaintenanceRepository::class, function (Container $app) {
-            return new MaintenanceRepository($app->make(Manager::class), $app);
+            return new MaintenanceRepository($app->make(FeaturesContract::class), $app);
         });
 
         $this->app->extend(MaintenanceModeManager::class, function (MaintenanceModeManager $manager) {

--- a/src/FeatureFlagsServiceProvider.php
+++ b/src/FeatureFlagsServiceProvider.php
@@ -45,6 +45,10 @@ class FeatureFlagsServiceProvider extends ServiceProvider
                 __DIR__.'/../migrations/create_features_table.php' => database_path('migrations/'.$migration),
             ], 'features-migration');
 
+            $this->publishes([
+                __DIR__.'/../stubs/PreventRequestsDuringMaintenance.php' => app_path('Http/Middleware/PreventRequestsDuringMaintenance.php'),
+            ], 'maintenance-middleware');
+
             // Registering package commands.
             if (Features::usesCommands()) {
                 $this->commands([

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -30,6 +30,7 @@ use YlsIdeas\FeatureFlags\Support\FeaturesFileDiscoverer;
 use YlsIdeas\FeatureFlags\Support\FileLoader;
 use YlsIdeas\FeatureFlags\Support\GatewayCache;
 use YlsIdeas\FeatureFlags\Support\GatewayInspector;
+use YlsIdeas\FeatureFlags\Support\MaintenanceRepository;
 
 /**
  * @see \YlsIdeas\FeatureFlags\Tests\ManagerTest
@@ -224,6 +225,11 @@ class Manager implements Contracts\Features
         $this->gatewayDrivers[$driver] = $builder;
 
         return $this;
+    }
+
+    public function maintenanceMode(): MaintenanceRepository
+    {
+        return $this->container->make(MaintenanceRepository::class);
     }
 
     protected function getContainer(): Container

--- a/src/Middlewares/PreventRequestsDuringMaintenance.php
+++ b/src/Middlewares/PreventRequestsDuringMaintenance.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace YlsIdeas\FeatureFlags\Middlewares;
+
+use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance as BasePreventRequestsDuringMaintenance;
+
+class PreventRequestsDuringMaintenance extends BasePreventRequestsDuringMaintenance
+{
+    public function getExcludedPaths()
+    {
+        return $this->app->maintenanceMode()->data()['except'] ?? [];
+    }
+}

--- a/src/Support/MaintenanceDriver.php
+++ b/src/Support/MaintenanceDriver.php
@@ -9,7 +9,6 @@ class MaintenanceDriver implements MaintenanceMode
 {
     public function __construct(protected MaintenanceContract $features)
     {
-
     }
 
     public function activate(array $payload): void

--- a/src/Support/MaintenanceDriver.php
+++ b/src/Support/MaintenanceDriver.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace YlsIdeas\FeatureFlags\Support;
+
+use Illuminate\Contracts\Foundation\MaintenanceMode;
+use YlsIdeas\FeatureFlags\Contracts\Maintenance as MaintenanceContract;
+
+class MaintenanceDriver implements MaintenanceMode
+{
+    public function __construct(protected MaintenanceContract $features)
+    {
+
+    }
+
+    public function activate(array $payload): void
+    {
+        $this->features->callActivation($payload);
+    }
+
+    public function deactivate(): void
+    {
+        $this->features->callDeactivation();
+    }
+
+    public function active(): bool
+    {
+        return $this->features->active();
+    }
+
+    public function data(): array
+    {
+        return $this->features->parameters() ?? [];
+    }
+}

--- a/src/Support/MaintenanceRepository.php
+++ b/src/Support/MaintenanceRepository.php
@@ -35,7 +35,7 @@ class MaintenanceRepository implements Maintenance
     public function callActivation(array $properties): void
     {
         $this->container->call($this->uponActivation, [
-            'properties' => $properties, 'features' => $this->features
+            'properties' => $properties, 'features' => $this->features,
         ]);
     }
 

--- a/src/Support/MaintenanceRepository.php
+++ b/src/Support/MaintenanceRepository.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace YlsIdeas\FeatureFlags\Support;
+
+use Illuminate\Contracts\Container\Container;
+use YlsIdeas\FeatureFlags\Contracts\Features;
+use YlsIdeas\FeatureFlags\Contracts\Maintenance;
+
+class MaintenanceRepository implements Maintenance
+{
+    public array $scenarios = [];
+
+    public ?MaintenanceScenario $foundScenario = null;
+    protected \Closure $uponActivation;
+    protected \Closure $uponDeactivation;
+
+    public function __construct(protected Features $features, protected Container $container)
+    {
+    }
+
+    public function uponActivation(callable $callable): static
+    {
+        $this->uponActivation = \Closure::fromCallable($callable);
+
+        return $this;
+    }
+
+    public function uponDeactivation(callable $callable): static
+    {
+        $this->uponDeactivation = \Closure::fromCallable($callable);
+
+        return $this;
+    }
+
+    public function callActivation(array $properties): void
+    {
+        $this->container->call($this->uponActivation, [
+            'properties' => $properties, 'features' => $this->features
+        ]);
+    }
+
+    public function callDeactivation(): void
+    {
+        $this->container->call($this->uponActivation, ['features' => $this->features]);
+    }
+
+    public function onEnabled($feature)
+    {
+        return tap((new MaintenanceScenario())->whenEnabled($feature), function (MaintenanceScenario $scenario) {
+            $this->scenarios[] = $scenario;
+        });
+    }
+
+    public function onDisabled($feature)
+    {
+        return tap((new MaintenanceScenario())->whenDisabled($feature), function (MaintenanceScenario $scenario) {
+            $this->scenarios[] = $scenario;
+        });
+    }
+
+    public function active(): bool
+    {
+        return (bool) $this->findScenario();
+    }
+
+    public function parameters(): ?array
+    {
+        return $this->foundScenario?->toArray();
+    }
+
+    protected function findScenario(): ?MaintenanceScenario
+    {
+        return $this->foundScenario = collect($this->scenarios)
+            ->first(function (MaintenanceScenario $scenario) {
+                if ($scenario->onEnabled && $this->features->accessible($scenario->feature)) {
+                    return true;
+                }
+                if (! $scenario->onEnabled && ! $this->features->accessible($scenario->feature)) {
+                    return true;
+                }
+
+                return false;
+            });
+    }
+}

--- a/src/Support/MaintenanceRepository.php
+++ b/src/Support/MaintenanceRepository.php
@@ -41,17 +41,17 @@ class MaintenanceRepository implements Maintenance
 
     public function callDeactivation(): void
     {
-        $this->container->call($this->uponActivation, ['features' => $this->features]);
+        $this->container->call($this->uponDeactivation, ['features' => $this->features]);
     }
 
-    public function onEnabled($feature)
+    public function onEnabled($feature): MaintenanceScenario
     {
         return tap((new MaintenanceScenario())->whenEnabled($feature), function (MaintenanceScenario $scenario) {
             $this->scenarios[] = $scenario;
         });
     }
 
-    public function onDisabled($feature)
+    public function onDisabled($feature): MaintenanceScenario
     {
         return tap((new MaintenanceScenario())->whenDisabled($feature), function (MaintenanceScenario $scenario) {
             $this->scenarios[] = $scenario;

--- a/src/Support/MaintenanceScenario.php
+++ b/src/Support/MaintenanceScenario.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace YlsIdeas\FeatureFlags\Support;
+
+use Illuminate\Contracts\Support\Arrayable;
+use YlsIdeas\FeatureFlags\Contracts\Maintenance;
+
+class MaintenanceScenario implements Arrayable
+{
+    public string $feature;
+    public bool $onEnabled;
+
+    protected array $attributes = [];
+
+    public function whenEnabled(string $feature): static
+    {
+        $this->feature = $feature;
+        $this->onEnabled = true;
+
+        return $this;
+    }
+
+    public function whenDisabled(string $feature): static
+    {
+        $this->feature = $feature;
+        $this->onEnabled = false;
+
+        return $this;
+    }
+
+    public function refresh(int $seconds): static
+    {
+        $this->attributes['refresh'] = (string) $seconds;
+
+        return $this;
+    }
+
+    public function statusCode(int $status): static
+    {
+        $this->attributes['status'] = $status;
+
+        return $this;
+    }
+
+    public function retry(int $seconds): static
+    {
+        $this->attributes['retry'] = $seconds;
+
+        return $this;
+    }
+
+    public function secret(string $secret): static
+    {
+        $this->attributes['secret'] = $secret;
+
+        return $this;
+    }
+
+    public function redirect(string $url): static
+    {
+        $this->attributes['redirect'] = $url;
+
+        return $this;
+    }
+
+    public function template(string $html): static
+    {
+        $this->attributes['template'] = $html;
+
+        return $this;
+    }
+
+    /**
+     * @param string[] $urls
+     */
+    public function exceptPaths(array $urls): static
+    {
+        $this->attributes['except'] = $urls;
+
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return $this->attributes;
+    }
+}

--- a/src/Support/MaintenanceScenario.php
+++ b/src/Support/MaintenanceScenario.php
@@ -3,7 +3,6 @@
 namespace YlsIdeas\FeatureFlags\Support;
 
 use Illuminate\Contracts\Support\Arrayable;
-use YlsIdeas\FeatureFlags\Contracts\Maintenance;
 
 class MaintenanceScenario implements Arrayable
 {

--- a/stubs/PreventRequestsDuringMaintenance.php
+++ b/stubs/PreventRequestsDuringMaintenance.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use YlsIdeas\FeatureFlags\Middlewares\PreventRequestsDuringMaintenance as Middleware;
+
+class PreventRequestsDuringMaintenance extends Middleware
+{
+}

--- a/tests/FeatureFlagsServiceProviderTest.php
+++ b/tests/FeatureFlagsServiceProviderTest.php
@@ -27,6 +27,8 @@ class FeatureFlagsServiceProviderTest extends TestCase
             File::delete(config_path('features.php'));
             File::delete(base_path('.features.php'));
 
+            File::delete(app_path('Http/Middleware/PreventRequestsDuringMaintenance.php.backup'));
+
             collect(File::files(database_path('migrations')))
                 ->each(fn (\SplFileInfo $file) => File::delete($file->getPathname()));
         });
@@ -81,6 +83,22 @@ class FeatureFlagsServiceProviderTest extends TestCase
 
         $this->assertNotNull($filename);
     }
+
+    public function test_publishes_the_maintenance_middleware(): void
+    {
+        $this->artisan('vendor:publish', [
+            '--tag' => 'maintenance-middleware',
+            '--force' => true,
+        ]);
+
+        $this->assertTrue(File::exists(app_path('Http/Middleware/PreventRequestsDuringMaintenance.php')));
+
+        $this->assertStringContainsString(
+            'use YlsIdeas\FeatureFlags\Middlewares\PreventRequestsDuringMaintenance as Middleware;',
+            File::get(app_path('Http/Middleware/PreventRequestsDuringMaintenance.php'))
+        );
+    }
+
 
     public function test_posting_about_info(): void
     {

--- a/tests/FeatureFlagsServiceProviderTest.php
+++ b/tests/FeatureFlagsServiceProviderTest.php
@@ -99,7 +99,6 @@ class FeatureFlagsServiceProviderTest extends TestCase
         );
     }
 
-
     public function test_posting_about_info(): void
     {
         if (version_compare(Application::VERSION, '9.20.0', '<')) {

--- a/tests/Kernel.php
+++ b/tests/Kernel.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace YlsIdeas\FeatureFlags\Tests;
+
+class Kernel extends \Orchestra\Testbench\Foundation\Http\Kernel
+{
+    protected $middleware = [
+        \YlsIdeas\FeatureFlags\Middlewares\PreventRequestsDuringMaintenance::class,
+    ];
+}

--- a/tests/MaintenanceModeTest.php
+++ b/tests/MaintenanceModeTest.php
@@ -2,11 +2,11 @@
 
 namespace YlsIdeas\FeatureFlags\Tests;
 
+use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
 use YlsIdeas\FeatureFlags\Facades\Features;
 use YlsIdeas\FeatureFlags\FeatureFlagsServiceProvider;
-use Illuminate\Contracts\Http\Kernel;
 
 class MaintenanceModeTest extends TestCase
 {
@@ -16,7 +16,7 @@ class MaintenanceModeTest extends TestCase
         Features::maintenanceMode()
             ->onEnabled('system.down');
 
-        Route::get('/', fn() => 'Foo Bar');
+        Route::get('/', fn () => 'Foo Bar');
 
         $this->get('/')
             ->assertStatus(503);
@@ -30,7 +30,7 @@ class MaintenanceModeTest extends TestCase
         Features::maintenanceMode()
             ->onEnabled('system.down');
 
-        Route::get('/', fn() => 'Foo Bar');
+        Route::get('/', fn () => 'Foo Bar');
 
         $this->get('/')
             ->assertOk();
@@ -48,7 +48,7 @@ class MaintenanceModeTest extends TestCase
             ->onEnabled('system.api')
             ->statusCode(500);
 
-        Route::get('/', fn() => 'Foo Bar');
+        Route::get('/', fn () => 'Foo Bar');
 
         $this->get('/')
             ->assertStatus(500);
@@ -80,8 +80,8 @@ class MaintenanceModeTest extends TestCase
             ->onEnabled('system.down')
             ->exceptPaths(['/test']);
 
-        Route::get('/', fn() => 'Foo Bar');
-        Route::get('/test', fn() => 'Foo Bar Foo');
+        Route::get('/', fn () => 'Foo Bar');
+        Route::get('/test', fn () => 'Foo Bar Foo');
 
         $this->get($path)
             ->assertStatus($status);

--- a/tests/MaintenanceModeTest.php
+++ b/tests/MaintenanceModeTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace YlsIdeas\FeatureFlags\Tests;
+
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+use YlsIdeas\FeatureFlags\Facades\Features;
+use YlsIdeas\FeatureFlags\FeatureFlagsServiceProvider;
+use Illuminate\Contracts\Http\Kernel;
+
+class MaintenanceModeTest extends TestCase
+{
+    public function test_maintenance_mode_enabled()
+    {
+        Features::fake(['system.down' => true]);
+        Features::maintenanceMode()
+            ->onEnabled('system.down');
+
+        Route::get('/', fn() => 'Foo Bar');
+
+        $this->get('/')
+            ->assertStatus(503);
+
+        Features::assertAccessed('system.down');
+    }
+
+    public function test_maintenance_mode_disabled()
+    {
+        Features::fake(['system.down' => false]);
+        Features::maintenanceMode()
+            ->onEnabled('system.down');
+
+        Route::get('/', fn() => 'Foo Bar');
+
+        $this->get('/')
+            ->assertOk();
+
+        Features::assertAccessed('system.down');
+    }
+
+    public function test_it_handles_the_first_match()
+    {
+        Features::fake(['system.api' => true,]);
+        Features::maintenanceMode()
+            ->onEnabled('system.down');
+
+        Features::maintenanceMode()
+            ->onEnabled('system.api')
+            ->statusCode(500);
+
+        Route::get('/', fn() => 'Foo Bar');
+
+        $this->get('/')
+            ->assertStatus(500);
+
+        Features::assertAccessed('system.down');
+        Features::assertAccessed('system.api');
+    }
+
+    public function test_upon_activation()
+    {
+        $called = false;
+        Features::maintenanceMode()
+            ->uponActivation(function () use (&$called) {
+                $called = true;
+            });
+
+        $this->artisan('down');
+
+        $this->assertTrue($called);
+    }
+
+    /**
+     * @dataProvider exceptsValues
+     */
+    public function test_maintenance_mode_respects_excepts_values(string $path, int $status)
+    {
+        Features::fake(['system.down' => true]);
+        Features::maintenanceMode()
+            ->onEnabled('system.down')
+            ->exceptPaths(['/test']);
+
+        Route::get('/', fn() => 'Foo Bar');
+        Route::get('/test', fn() => 'Foo Bar Foo');
+
+        $this->get($path)
+            ->assertStatus($status);
+
+        Features::assertAccessed('system.down');
+    }
+
+    public function exceptsValues(): \Generator
+    {
+        yield 'blocked' => [
+            '/', 503,
+        ];
+        yield 'allowed' => [
+            '/test', 200,
+        ];
+    }
+
+    public function test_upon_deactivation()
+    {
+        $called = false;
+        Features::fake(['system.down' => true]);
+
+        Features::maintenanceMode()
+            ->uponDeactivation(function () use (&$called) {
+                $called = true;
+            })
+            ->onEnabled('system.down');
+
+        $this->artisan('up');
+
+        $this->assertTrue($called);
+    }
+
+    protected function defineEnvironment($app): void
+    {
+        config()->set('app.maintenance.driver', 'features');
+        config()->set('features.pipeline', []);
+    }
+
+    /**
+     * Resolve application HTTP Kernel implementation.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return void
+     */
+    protected function resolveApplicationHttpKernel($app)
+    {
+        // Required to establish the package's PreventRequestsDuringMaintenance middleware
+        // over the default installed by Laravel
+        $app->singleton(
+            Kernel::class,
+            \YlsIdeas\FeatureFlags\Tests\Kernel::class
+        );
+    }
+
+    protected function getPackageProviders($app): array
+    {
+        return [
+            FeatureFlagsServiceProvider::class,
+        ];
+    }
+}

--- a/tests/Support/MaintenanceScenarioTest.php
+++ b/tests/Support/MaintenanceScenarioTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace YlsIdeas\FeatureFlags\Tests\Support;
+
+use PHPUnit\Framework\TestCase;
+use YlsIdeas\FeatureFlags\Support\MaintenanceScenario;
+
+class MaintenanceScenarioTest extends TestCase
+{
+    /**
+     * @dataProvider scenarioOptions
+     */
+    public function test_it_builds_a_maintenance_scenario(callable $builder, bool $polarity, array $result)
+    {
+        $scenario = new MaintenanceScenario();
+        /** @var MaintenanceScenario $scenario */
+        $scenario = $builder($scenario);
+
+        $this->assertSame($polarity, $scenario->onEnabled);
+        $this->assertSame($result, $scenario->toArray());
+    }
+
+    public function scenarioOptions(): \Generator
+    {
+        yield 'secret' => [
+            fn (MaintenanceScenario $scenario): MaintenanceScenario => $scenario
+                ->whenEnabled('feature')
+                ->secret('my-password'),
+            true,
+            ['secret' => 'my-password']
+        ];
+
+        yield 'except' => [
+            fn (MaintenanceScenario $scenario): MaintenanceScenario => $scenario
+                ->whenEnabled('feature')
+                ->exceptPaths(['/', '/nova/*']),
+            true,
+            ['except' => ['/', '/nova/*']],
+        ];
+
+        yield 'retry' => [
+            fn (MaintenanceScenario $scenario): MaintenanceScenario => $scenario
+                ->whenEnabled('feature')
+                ->retry(10),
+            true,
+            ['retry' => 10],
+        ];
+
+        yield 'refresh' => [
+            fn (MaintenanceScenario $scenario): MaintenanceScenario => $scenario
+                ->whenEnabled('feature')
+                ->refresh(10),
+            true,
+            ['refresh' => '10'],
+        ];
+
+        yield 'status' => [
+            fn (MaintenanceScenario $scenario): MaintenanceScenario => $scenario
+                ->whenEnabled('feature')
+                ->statusCode(500),
+            true,
+            ['status' => 500],
+        ];
+
+        yield 'redirect' => [
+            fn (MaintenanceScenario $scenario): MaintenanceScenario => $scenario
+                ->whenEnabled('feature')
+                ->redirect('/'),
+            true,
+            ['redirect' => '/'],
+        ];
+
+        yield 'template' => [
+            fn (MaintenanceScenario $scenario): MaintenanceScenario => $scenario
+                ->whenEnabled('feature')
+                ->template('<p>test</p>'),
+            true,
+            ['template' => '<p>test</p>'],
+        ];
+
+        yield 'disabled' => [
+            fn (MaintenanceScenario $scenario): MaintenanceScenario => $scenario
+                ->whenDisabled('feature'),
+            false,
+            [],
+        ];
+    }
+}

--- a/tests/Support/MaintenanceScenarioTest.php
+++ b/tests/Support/MaintenanceScenarioTest.php
@@ -27,7 +27,7 @@ class MaintenanceScenarioTest extends TestCase
                 ->whenEnabled('feature')
                 ->secret('my-password'),
             true,
-            ['secret' => 'my-password']
+            ['secret' => 'my-password'],
         ];
 
         yield 'except' => [


### PR DESCRIPTION
## Changes In Code

* Added a Maintenance Mode driver
* Adds tests for this
* Adds an extension of the `PreventRequestsDuringMaintenance` to allow the use of the `except` value otherwise, this won't work.

## Issue ticket number / Business Case

Maintenance Mode within the package will allow for more complex configurations where the feature flags decide the state of maintenance mode and how the application should handle things in the event of a problem.

Example code:

```
Features::maintenanceMode()
            ->onEnabled('system.api')
            ->statusCode(500);
```

## Checklist before requesting a review
- [x] I have written PHP tests.
- [x] I have updated the documentation in the readme where needed.
- [x] I have checked code styles, PHPStan etc. pass.
- [x] I have provided an issue/business case.
