### PR TITLE
Type-hint contract instead of concrete class to allow switching features

### DIFF
--- a/src/Support/FeatureFake.php
+++ b/src/Support/FeatureFake.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\Assert;
 use YlsIdeas\FeatureFlags\Contracts\Features;
 use YlsIdeas\FeatureFlags\Events\FeatureAccessed;
 use YlsIdeas\FeatureFlags\Events\FeatureAccessing;
-use YlsIdeas\FeatureFlags\Manager;
 
 /**
  * @see \YlsIdeas\FeatureFlags\Tests\Support\FeatureFakeTest
@@ -23,7 +22,7 @@ class FeatureFake implements Features
     /**
      * @param array<string, bool|array> $featureFlags
      */
-    public function __construct(protected Manager $manager, protected array $featureFlags = [])
+    public function __construct(protected Features $manager, protected array $featureFlags = [])
     {
     }
 

--- a/tests/Support/FeatureFakeTest.php
+++ b/tests/Support/FeatureFakeTest.php
@@ -47,6 +47,14 @@ class FeatureFakeTest extends TestCase
         $this->assertTrue($fake->accessible('my-feature'));
     }
 
+    public function test_it_can_switch_a_feature_multiple_times()
+    {
+        Features::fake(['my-feature' => true]);
+        Features::fake(['my-feature' => false]);
+
+        $this->assertFalse(Features::accessible('my-feature'));
+    }
+
     public function test_it_can_be_fake_accessibility_results_from_the_container()
     {
         Event::fake();


### PR DESCRIPTION
## Changes In Code

When we fake a feature via the `Features::fake` method, the manager instance is swapped with `FeatureFake`.

Calling `fake` more than once will result in the following error:
``` 
YlsIdeas\FeatureFlags\Support\FeatureFake::__construct(): Argument #1 ($manager) must be of type YlsIdeas\FeatureFlags\Manager, YlsIdeas\FeatureFlags\Support\FeatureFake given [...]
```

This happens because `FeatureFake` type-hints at a `Manager` instance but after `Features::fake` has been called for the first time, the facade root will return an instance of `FeatureFake` instead.

To fix that, I changed the type expected for the `$manager` property to the `Features` contract.

## Issue ticket number / Business Case
Switching a feature state can be useful in tests.

In my specific case, I noticed the issue when I faked a feature in a test `setUp` but had one specific test case where the feature had to be switched, resulting in the error.


## Checklist before requesting a review
- [x] I have written PHPUnit tests.
- [ ] I have updated the documentation and opened a pull request within
the [feature flags documentation repo](https://github.com/ylsideas/feature-flags-docs).
- [x] I have checked code styles, PHPStan etc. pass.
- [x] I have provided an issue/business case.
- [ ] I have added the `enhancement` label for a new feature.
