### PR TITLE
Allows for multiple fakes to occur

### DIFF
--- a/src/Facades/Features.php
+++ b/src/Facades/Features.php
@@ -3,6 +3,7 @@
 namespace YlsIdeas\FeatureFlags\Facades;
 
 use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Testing\Fakes\Fake;
 use YlsIdeas\FeatureFlags\Contracts\Features as FeaturesContract;
 use YlsIdeas\FeatureFlags\Support\FeatureFake;
 
@@ -44,7 +45,11 @@ class Features extends Facade
      */
     public static function fake(array $flagsToFake = []): FeatureFake
     {
-        static::swap($fake = new FeatureFake(static::getFacadeRoot(), $flagsToFake));
+        $manager = static::isFake()
+            ? static::getFacadeRoot()->manager()
+            : static::getFacadeRoot();
+
+        static::swap($fake = new FeatureFake($manager, $flagsToFake));
 
         return $fake;
     }

--- a/src/Facades/Features.php
+++ b/src/Facades/Features.php
@@ -30,7 +30,6 @@ use YlsIdeas\FeatureFlags\Support\FeatureFake;
  * @method static \static applyOnExpiredHandler(\YlsIdeas\FeatureFlags\Contracts\ExpiredFeaturesHandler $handler)
  * @method static \static extend(string $driver, callable $builder)
  * @method static \YlsIdeas\FeatureFlags\Support\MaintenanceRepository maintenanceMode()
- * @method static \YlsIdeas\FeatureFlags\Manager manager()
  * @method static void assertAccessed(string $feature, int|null $count = null, string $message = '')
  * @method static void assertNotAccessed(string $feature, string $message = '')
  * @method static void assertAccessedCount(string $feature, int $count = 0, string $message = '')
@@ -47,7 +46,7 @@ class Features extends Facade
     public static function fake(array $flagsToFake = []): FeatureFake
     {
         $manager = static::isFake()
-            ? static::getFacadeRoot()->manager()
+            ? static::getFacadeRoot()->manager
             : static::getFacadeRoot();
 
         static::swap($fake = new FeatureFake($manager, $flagsToFake));

--- a/src/FeatureFlagsServiceProvider.php
+++ b/src/FeatureFlagsServiceProvider.php
@@ -109,7 +109,6 @@ class FeatureFlagsServiceProvider extends ServiceProvider
             /** @noRector \Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector */
             Event::macro('skipWithoutFeature', fn (string $feature): Event =>
                 /** @var Event $this */
-                /** @phpstan-ignore-next-line annoying issue with macros */
                 $this->skip(fn () => ! Features::accessible($feature)));
         }
 
@@ -117,7 +116,6 @@ class FeatureFlagsServiceProvider extends ServiceProvider
             /** @noRector \Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector */
             Event::macro('skipWithFeature', fn ($feature): Event =>
                 /** @var Event $this */
-                /** @phpstan-ignore-next-line annoying issue with macros */
                 $this->skip(fn () => Features::accessible($feature)));
         }
     }

--- a/src/Support/FeatureFake.php
+++ b/src/Support/FeatureFake.php
@@ -24,13 +24,8 @@ class FeatureFake implements Features, Fake
     /**
      * @param array<string, bool|array> $featureFlags
      */
-    public function __construct(protected Manager $manager, protected array $featureFlags = [])
+    public function __construct(public Manager $manager, protected array $featureFlags = [])
     {
-    }
-
-    public function manager(): Manager
-    {
-        return $this->manager;
     }
 
     public function accessible(string $feature): bool

--- a/src/Support/FeatureFake.php
+++ b/src/Support/FeatureFake.php
@@ -4,6 +4,7 @@ namespace YlsIdeas\FeatureFlags\Support;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Testing\Fakes\Fake;
 use Illuminate\Support\Traits\ForwardsCalls;
 use PHPUnit\Framework\Assert;
 use YlsIdeas\FeatureFlags\Contracts\Features;
@@ -14,7 +15,7 @@ use YlsIdeas\FeatureFlags\Manager;
 /**
  * @see \YlsIdeas\FeatureFlags\Tests\Support\FeatureFakeTest
  */
-class FeatureFake implements Features
+class FeatureFake implements Features, Fake
 {
     use ForwardsCalls;
 
@@ -25,6 +26,11 @@ class FeatureFake implements Features
      */
     public function __construct(protected Manager $manager, protected array $featureFlags = [])
     {
+    }
+
+    public function manager(): Manager
+    {
+        return $this->manager;
     }
 
     public function accessible(string $feature): bool

--- a/tests/Support/FeatureFakeTest.php
+++ b/tests/Support/FeatureFakeTest.php
@@ -148,6 +148,14 @@ class FeatureFakeTest extends TestCase
         Event::assertDispatched(FeatureAccessed::class);
     }
 
+    public function test_it_can_switch_a_feature_multiple_times()
+    {
+        Features::fake(['my-feature' => true]);
+        Features::fake(['my-feature' => false]);
+
+        $this->assertFalse(Features::accessible('my-feature'));
+    }
+
     protected function getFake($manager, $features)
     {
         return new class ($manager, $features) extends FeatureFake {


### PR DESCRIPTION
## Changes In Code

* FeatureFake now implements the Fake interface
* FeatureFake manager property is now public
* The Facade now checks if the Features interface is already faked in the container and reuses the manager when faking additional times.

## Issue ticket number / Business Case

Slightly improved implementation of #66 

## Checklist before requesting a review
- [x] I have written PHPUnit tests.
- [ ] I have updated the documentation and opened a pull request within
the [feature flags documentation repo](https://github.com/ylsideas/feature-flags-docs).
- [x] I have checked code styles, PHPStan etc. pass.
- [x] I have provided an issue/business case.
- [ ] I have added the `enhancement` label for a new feature.
