### PR TITLE
change instance of manager

### DIFF
--- a/src/Middlewares/GuardFeature.php
+++ b/src/Middlewares/GuardFeature.php
@@ -7,7 +7,7 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Translation\Translator;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
-use YlsIdeas\FeatureFlags\Manager;
+use YlsIdeas\FeatureFlags\Contracts\Features;
 use YlsIdeas\FeatureFlags\Support\StateChecking;
 
 /**
@@ -18,7 +18,7 @@ class GuardFeature
     use StateChecking;
 
     public function __construct(
-        protected Manager $manager,
+        protected Features $manager,
         protected Application $application,
         protected Translator $translator,
     ) {


### PR DESCRIPTION
it allows laravel service container to use mocked class instead concrete manager

## Changes In Code

FeatureGuard is the class that resolve when middleware like `feature:my-feature` is declared in routes

the parameter `$manager` in the construct method is for a concrete class. Substituting that for the `YlsIdeas\FeatureFlags\Contracts\Features` interface allows the service container of laravel to replace with a fake instance when use the fake of facade `Features::fake(['my-feature' => true])`.

 
## Issue ticket number / Business Case

https://github.com/ylsideas/feature-flags/issues/70

## Checklist before requesting a review
- [ ] I have written PHPUnit tests.
- [ ] I have updated the documentation and opened a pull request within
the [feature flags documentation repo](https://github.com/ylsideas/feature-flags-docs).
- [ ] I have checked code styles, PHPStan etc. pass.
- [x] I have provided an issue/business case.
- [ ] I have added the `enhancement` label for a new feature.
