### PR TITLE
Force casting cache result to boolean

### DIFF
--- a/src/Support/GatewayCache.php
+++ b/src/Support/GatewayCache.php
@@ -3,6 +3,7 @@
 namespace YlsIdeas\FeatureFlags\Support;
 
 use Illuminate\Contracts\Cache\Repository;
+use Psr\SimpleCache\InvalidArgumentException;
 use YlsIdeas\FeatureFlags\Contracts\Cacheable;
 
 /**
@@ -21,9 +22,12 @@ class GatewayCache
         return $this->repository->has($this->generateKey($feature));
     }
 
+    /**
+     * @throws InvalidArgumentException
+     */
     public function result(string $feature): bool
     {
-        return $this->repository->get($this->generateKey($feature));
+        return (bool) $this->repository->get($this->generateKey($feature));
     }
 
     public function store(string $feature, ?bool $result): void

--- a/tests/Support/GatewayCacheTest.php
+++ b/tests/Support/GatewayCacheTest.php
@@ -33,6 +33,26 @@ class GatewayCacheTest extends TestCase
         $this->assertTrue($cache->hits('my-feature'));
     }
 
+    public function test_it_retrieves_the_cache_correctly(): void
+    {
+        $repository = Mockery::mock(Repository::class);
+        $cachable = Mockery::mock(Cacheable::class);
+
+        $cachable->shouldReceive('generateKey')
+            ->with('my-feature')
+            ->once()
+            ->andReturn('key');
+
+        $repository->shouldReceive('get')
+            ->with('test:key')
+            ->once()
+            ->andReturn(null);
+
+        $cache = new GatewayCache($repository, 'test', $cachable);
+
+        $this->assertFalse($cache->result('my-feature'));
+    }
+
     public function test_it_stores_with_a_ttl_correctly(): void
     {
         $repository = Mockery::mock(Repository::class);


### PR DESCRIPTION
## Changes In Code

- uses a boolean cast in `GatewayCache::result()`

## Issue ticket number / Business Case

#69 

## Checklist before requesting a review
- [x] I have written PHPUnit tests.
- [x] I have checked code styles, PHPStan etc. pass.
- [x] I have provided an issue/business case.
