### PR TITLE
Fix deprecated implicit nullable parameter

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -208,7 +208,7 @@ class Manager implements Features
         return $this->useQueryBuilderMixin;
     }
 
-    public function callOnExpiredFeatures(array $expiredFeatures, callable $handler = null): static
+    public function callOnExpiredFeatures(array $expiredFeatures, ?callable $handler = null): static
     {
         $handler ??= static function ($feature): void {
             throw new FeatureExpired($feature);


### PR DESCRIPTION
## Changes In Code

Implicitly nullable parameters are deprecated in PHP 8.4.

In this pull request, I am explicitly declaring the `$handler` parameter as nullable to avoid deprecation warnings.

## Issue ticket number / Business Case

The current implementation throws a deprecation warning every time a feature is checked in PHP 8.4 codebases.

## Checklist before requesting a review
- [ ] I have written PHPUnit tests.
- [ ] I have updated the documentation and opened a pull request within
the [feature flags documentation repo](https://github.com/ylsideas/feature-flags-docs).
- [x] I have checked code styles, PHPStan etc. pass.
- [x] I have provided an issue/business case.
- [ ] I have added the `enhancement` label for a new feature.
